### PR TITLE
Add DataSpoc Lens to Command-line tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@
 ### Command-line
 
 - [DataFusion CLI](https://datafusion.apache.org/user-guide/cli/overview.html) - A single, dependency-free executable that can read and write Parquet files, with a SQL interface.
+- [DataSpoc Pipe](https://github.com/dataspoclab/dataspoc-pipe) - A data ingestion CLI that connects 400+ Singer taps to Parquet files in cloud buckets (S3, GCS, Azure).
 - [DuckDB CLI](https://duckdb.org/docs/stable/clients/cli/overview.html) - A single, dependency-free executable that can read and write Parquet files, with a SQL interface.
 - [nail](https://github.com/Vitruves/nail-parquet) - Command-line tool for analyzing, transforming, and exploring data files.
 - [ODBC to Parquet](https://github.com/pacman82/odbc2parquet) - A command-line tool to query an ODBC data source and write the result into a parquet file.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@
 ### Command-line
 
 - [DataFusion CLI](https://datafusion.apache.org/user-guide/cli/overview.html) - A single, dependency-free executable that can read and write Parquet files, with a SQL interface.
+- [DataSpoc Lens](https://github.com/dataspoclab/dataspoc-lens) - A virtual warehouse CLI that mounts cloud Parquet as DuckDB views, with interactive SQL shell, Jupyter/Marimo notebooks, and AI queries.
 - [DataSpoc Pipe](https://github.com/dataspoclab/dataspoc-pipe) - A data ingestion CLI that connects 400+ Singer taps to Parquet files in cloud buckets (S3, GCS, Azure).
 - [DuckDB CLI](https://duckdb.org/docs/stable/clients/cli/overview.html) - A single, dependency-free executable that can read and write Parquet files, with a SQL interface.
 - [nail](https://github.com/Vitruves/nail-parquet) - Command-line tool for analyzing, transforming, and exploring data files.


### PR DESCRIPTION
[DataSpoc Lens](https://github.com/dataspoclab/dataspoc-lens) is an open-source CLI that mounts cloud Parquet files (S3/GCS/Azure) as DuckDB views for interactive SQL queries, Jupyter/Marimo notebooks, and AI-assisted analytics.

- **PyPI**: https://pypi.org/project/dataspoc-lens/
- **License**: Apache 2.0

Added to Tools > Command-line in alphabetical order.