### PR TITLE
Add Enrich.sh to Tools 

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@
 
 - [DataFusion CLI](https://datafusion.apache.org/user-guide/cli/overview.html) - A single, dependency-free executable that can read and write Parquet files, with a SQL interface.
 - [DuckDB CLI](https://duckdb.org/docs/stable/clients/cli/overview.html) - A single, dependency-free executable that can read and write Parquet files, with a SQL interface.
+- [Enrich.sh](https://enrich.sh) - REST API that ingests JSON events and stores them as Parquet files in Cloudflare R2 with automatic Hive-style time partitioning.
 - [nail](https://github.com/Vitruves/nail-parquet) - Command-line tool for analyzing, transforming, and exploring data files.
 - [ODBC to Parquet](https://github.com/pacman82/odbc2parquet) - A command-line tool to query an ODBC data source and write the result into a parquet file.
 - [parquet-tools](https://pypi.org/project/parquet-tools/) - Python-based CLI tool for exploring parquet files (part of Apache Arrow).


### PR DESCRIPTION
Enrich.sh ingests JSON events through a REST API and writes them as Hive-partitioned Parquet files to Cloudflare R2, turning live event streams into a queryable Parquet dataset without a broker or data engineering stack on the user's side.

 t complements entries like DBConvert Streams and Munquet that handle batch conversion into Parquet, by covering the streaming and append case rather than one-shot file conversion. 

The output is standard Parquet with row-group sizing and partition pruning aligned to the engines already on this list (DuckDB, Arrow, ClickHouse, Spark), so users of those tools gain a direct ingestion path that produces files they can already read.