### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@
 
 - [duckdb-swift](https://duckdb.org/docs/stable/clients/swift) - DuckDB Swift client.
 
+### VBA
+
+- [duckdb-vba](https://github.com/EtienneLenoir/duckdb-vba) - Excel/VBA bridge for DuckDB, enabling users to read, query, transform, and export Parquet files directly from Excel through a native DLL bridge.
+
 ## Tools
 
 ### Command-line


### PR DESCRIPTION
Add duckdb-vba to the Libraries section under a new VBA subsection.

duckdb-vba brings Parquet support to Excel/VBA through a native DuckDB DLL bridge, addressing a format that has very limited native support in the VBA ecosystem. It enables users to read, query, transform, and export Parquet files directly from Excel.