### PR TITLE
Add ParquetKit to Tools > Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@
 - [Onyxia Data Explorer](https://datalab.sspcloud.fr/data-explorer) - A web-based tool to explore Parquet files in the browser.
 - [Parquet File Visualizer](https://julien.ledem.net/experiment/parquet-visualizer.html) - Claude-code generated parquet metadata visualizer that runs in your browser.
 - [Parquet Viewer](https://parquet-viewer.xiangpeng.systems/) - View parquet files online.
+- [ParquetKit](https://parquetkit.com) - View, query with SQL, and convert Parquet files entirely in the browser, powered by DuckDB-Wasm and hyparquet.
 - [Quak](https://manzt.github.io/quak) - A scalable data profiler for quickly scanning large tables.
 
 ## Resources


### PR DESCRIPTION
**What it is**: [ParquetKit](https://parquetkit.com) — view, query with SQL (DuckDB-Wasm), and convert Parquet files entirely in the browser. Uses hyparquet for instant metadata/preview reads.

**Why it fits**: client-side web tool for Parquet, inserted in alphabetical order in Tools > Web.

MIT licensed and documented: https://github.com/XxxKMSxxX/parquetkit