### PR TITLE
Add Agentsor File Contracts to command-line tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@
 
 ### Command-line
 
+- [Agentsor File Contracts](https://github.com/linkoinsight/agentsor-file) - Python CLI that validates completed local CSV and Parquet files against explicit schema, freshness, row, and byte contracts, with optional redacted receipts for rolling missed-run alerts.
 - [DataFusion CLI](https://datafusion.apache.org/user-guide/cli/overview.html) - A single, dependency-free executable that can read and write Parquet files, with a SQL interface.
 - [DuckDB CLI](https://duckdb.org/docs/stable/clients/cli/overview.html) - A single, dependency-free executable that can read and write Parquet files, with a SQL interface.
 - [nail](https://github.com/Vitruves/nail-parquet) - Command-line tool for analyzing, transforming, and exploring data files.


### PR DESCRIPTION
Adds Agentsor File Contracts to Tools → Command-line.

Why it fits: the maintained MIT-licensed Python CLI validates completed local Parquet (and CSV) files against explicit schema, freshness, row-count, and byte-count contracts. Its optional hosted deadline mode receives only a fixed redacted result receipt and alerts when the rolling receipt deadline is missed.

Guideline check:

- The source is public and open source.
- The project is maintained, documented, and available on PyPI.
- The entry is alphabetical, concise, starts with uppercase text, and ends with a period.
- No existing Agentsor entry or pull request was found.

Affiliation disclosure: this submission comes from the project maintainer account.
